### PR TITLE
Tweak the Proper Noun

### DIFF
--- a/src/main/resources/assets/qmd/lang/zh_cn.lang
+++ b/src/main/resources/assets/qmd/lang/zh_cn.lang
@@ -599,9 +599,9 @@ tile.qmd.accelerator_cooling.name=加速器冷却
 tile.qmd.cell_filling.name=单元灌注与提取
 
 //标签
-itemGroup.qmd.items=量子动力丨物品
-itemGroup.qmd.blocks=量子动力丨方块
-itemGroup.qmd.multiblocks=量子动力丨结构
+itemGroup.qmd.items=量子动力学丨物品
+itemGroup.qmd.blocks=量子动力学丨方块
+itemGroup.qmd.multiblocks=量子动力学丨结构
 
 //方块设置
 qmd.block.accelerator_port_setting_toggle=调整端口红石设置至：


### PR DESCRIPTION
Quantum Dynamics is a subject, not "motive force".
So I add “学”, which in Chinese refers to a realm of learning.