### PR TITLE
CHS Translation for 0.13.3

### DIFF
--- a/src/main/resources/assets/qmd/lang/zh_cn.lang
+++ b/src/main/resources/assets/qmd/lang/zh_cn.lang
@@ -70,21 +70,21 @@ item.qmd.canister.hydrogen.name=氢罐
 item.qmd.canister.helium.name=氦罐
 item.qmd.canister.deuterium.name=氘罐
 item.qmd.canister.diborane.name=乙硼烷罐
-item.qmd.canister.helium3.name=氦-3罐
+item.qmd.canister.helium3.name=氦-3 罐
 item.qmd.canister.tritium.name=氚罐
 
 item.qmd.source.tungsten_filament.name=钨丝
-item.qmd.source.sodium_22.name=钠-22源
-item.qmd.source.cobalt_60.name=钴-60源
-item.qmd.source.iridium_192.name=铱-192源
-item.qmd.source.calcium_48.name=钙-48源
+item.qmd.source.sodium_22.name=钠-22 源
+item.qmd.source.cobalt_60.name=钴-60 源
+item.qmd.source.iridium_192.name=铱-192 源
+item.qmd.source.calcium_48.name=钙-48 源
 
 item.qmd.isotope.sodium_22.name=钠-22
 item.qmd.isotope.magnesium_26.name=镁-26
 item.qmd.isotope.magnesium_24.name=镁-24
 item.qmd.isotope.beryllium_7.name=铍-7
 item.qmd.isotope.uranium_234.name=铀-234
-item.qmd.isotope.protactinium_231.name=镤-231粉
+item.qmd.isotope.protactinium_231.name=镤-231 粉
 item.qmd.isotope.cobalt_60.name=钴-60
 item.qmd.isotope.iridium_192.name=铱-192
 item.qmd.isotope.calcium_48.name=钙-48
@@ -101,8 +101,8 @@ item.qmd.part.magnet_nd.name=钕磁铁
 item.qmd.part.accelerating_barrel.name=加速膛
 item.qmd.part.laser_assembly.name=激光器组件
 
-item.qmd.semiconductor.silicon_p_doped.name=P型掺杂硅
-item.qmd.semiconductor.silicon_n_doped.name=N型掺杂硅
+item.qmd.semiconductor.silicon_p_doped.name=P 型掺杂硅
+item.qmd.semiconductor.silicon_n_doped.name=N 型掺杂硅
 item.qmd.semiconductor.silicon_boule.name=硅晶柱
 item.qmd.semiconductor.silicon_wafer.name=硅晶片
 item.qmd.semiconductor.basic_processor.name=基础处理器
@@ -137,11 +137,11 @@ item.qmd.cell.empty.name=空单元
 item.qmd.cell.antihydrogen.name=反氢单元
 item.qmd.cell.antideuterium.name=反氘单元
 item.qmd.cell.antitritium.name=反氚单元
-item.qmd.cell.antihelium3.name=反氦-3单元
+item.qmd.cell.antihelium3.name=反氦-3 单元
 item.qmd.cell.antihelium.name=反氦单元
 item.qmd.cell.positronium.name=正电子偶素单元
-item.qmd.cell.muonium.name=μ轻子偶素单元
-item.qmd.cell.tauonium.name=τ轻子偶素单元
+item.qmd.cell.muonium.name=μ 轻子偶素单元
+item.qmd.cell.tauonium.name=τ 轻子偶素单元
 item.qmd.cell.glueballs.name=胶子单元
 
 item.qmd.copernicium.291.name=鎶-291
@@ -152,11 +152,11 @@ item.qmd.copernicium.291_za.name=鎶-291-锆合金
 
 item.qmd.pellet_copernicium.mix_291.name=混合物-291 燃料
 item.qmd.pellet_copernicium.mix_291_c.name=混合物-291 燃料 碳化物
-item.qmd.fuel_copernicium.mix_291_tr.name=混合TRISO-291 燃料颗粒
+item.qmd.fuel_copernicium.mix_291_tr.name=混合 TRISO-291 燃料颗粒
 item.qmd.fuel_copernicium.mix_291_ox.name=混合氧化物-291 燃料丸
 item.qmd.fuel_copernicium.mix_291_ni.name=混合氮化物-291 燃料丸
 item.qmd.fuel_copernicium.mix_291_za.name=混合锆合金-291 燃料丸
-item.qmd.depleted_fuel_copernicium.mix_291_tr.name=枯竭 混合TRISO-291 燃料颗粒
+item.qmd.depleted_fuel_copernicium.mix_291_tr.name=枯竭 混合 TRISO-291 燃料颗粒
 item.qmd.depleted_fuel_copernicium.mix_291_ox.name=枯竭 混合氧化物-291 燃料丸
 item.qmd.depleted_fuel_copernicium.mix_291_ni.name=枯竭 混合氮化物-291 燃料丸
 item.qmd.depleted_fuel_copernicium.mix_291_za.name=枯竭 混合锆合金-291 燃料丸
@@ -164,10 +164,10 @@ item.qmd.depleted_fuel_copernicium.mix_291_za.name=枯竭 混合锆合金-291 �
 item.qmd.lepton_cannon.name=轻子炮
 item.qmd.gluon_gun.name=胶子枪
 
-item.qmd.helm_hev.name=HEV头盔
-item.qmd.chest_hev.name=HEV胸甲
-item.qmd.legs_hev.name=HEV护腿
-item.qmd.boots_hev.name=HEV靴子
+item.qmd.helm_hev.name=HEV 头盔
+item.qmd.chest_hev.name=HEV 胸甲
+item.qmd.legs_hev.name=HEV 护腿
+item.qmd.boots_hev.name=HEV 靴子
 # ~~译名来源：萌百半条命页面。本人从未游玩过半条命系列，译名如有问题还请指正~~
 # HEV: Hazardous EnVironment，萌百译名「危险环境」，现已弃用并保留原文
 
@@ -294,8 +294,8 @@ qmd.guide_book.edition=未完成
 qmd.guide_book.desc=这是本模组的指导手册。本书目前尚未完成，因此请前往维基获取相关信息。
 
 //死亡信息
-death.attack.gluon_gun=%1$s被%2$s用胶子枪汽化了
-death.attack.lepton_cannon=%1$s被%2$s用轻子炮杀死了
+death.attack.gluon_gun=%1$s 被 %2$s 用胶子枪汽化了
+death.attack.lepton_cannon=%1$s 被 %2$s 用轻子炮杀死了
 
 //方块描述
 tile.qmd.beamline.desc=运输粒子。
@@ -307,22 +307,22 @@ tile.qmd.rf_cavity.desc=用射频电场加速带电粒子。若想构造有效�
 
 tile.qmd.accelerator_magnet.desc=以强磁场弯曲带电粒子的运动轨迹。可用于构造四极或双极磁铁。若想构造有效四极磁铁结构则束流方块必须被四个种类相同的电磁铁环绕。
 
-tile.qmd.accelerator_yoke.desc=形成、加强电磁铁的磁场。可用于构造双极磁铁。若想构造有效双极磁铁结构则束流方块的上方与下方都必须有一个电磁铁，周围3x3x3范围内束流方块与电磁铁以外的所有空位都必须以电磁轭填充。
+tile.qmd.accelerator_yoke.desc=形成、加强电磁铁的磁场。可用于构造双极磁铁。若想构造有效双极磁铁结构则束流方块的上方与下方都必须有一个电磁铁，周围 3x3x3 范围内束流方块与电磁铁以外的所有空位都必须以电磁轭填充。
 
-tile.qmd.particle_chamber.detector.bubble_chamber.desc=必须被放置在距粒子室2格处。
-tile.qmd.particle_chamber.detector.wire_chamber.desc=必须被放置在距粒子室2格处。
+tile.qmd.particle_chamber.detector.bubble_chamber.desc=必须被放置在距粒子室 2 格处。
+tile.qmd.particle_chamber.detector.wire_chamber.desc=必须被放置在距粒子室 2 格处。
 tile.qmd.particle_chamber.detector.silicon_tracker.desc=必须被放置在与粒子室相邻处。
-tile.qmd.particle_chamber.detector.em_calorimeter.desc=必须被放置在距粒子室3格处。
-tile.qmd.particle_chamber.detector.hadron_calorimeter.desc=必须被放置在距粒子室5格处。
+tile.qmd.particle_chamber.detector.em_calorimeter.desc=必须被放置在距粒子室 3 格处。
+tile.qmd.particle_chamber.detector.hadron_calorimeter.desc=必须被放置在距粒子室 5 格处。
 
 //item descriptions
 item.qmd.lepton_cannon.desc=拥有强大威力的波束武器。攻击可以穿透方块和盔甲。
 item.qmd.gluon_gun.desc=拥有强大威力的波束武器。可以快速挖掘任何方块。
 
-item.qmd.helm_hev.desc=使穿戴者不会获得中毒效果，并将凋零效果时长减少至4秒。
+item.qmd.helm_hev.desc=使穿戴者不会获得中毒效果，并将凋零效果时长减少至 4 秒。
 item.qmd.chest_hev.desc=让穿戴者可以在疾跑时跳得更长。
-item.qmd.legs_hev.desc=让穿戴者可以跳到2.5格高，并给予速度效果。
-item.qmd.boots_hev.desc=为穿戴者提供移动辅助，减少掉落伤害至掉落高度减少4格的等级，并降低一半的掉落伤害。
+item.qmd.legs_hev.desc=让穿戴者可以跳到 2.5 格高，并给予速度效果。
+item.qmd.boots_hev.desc=为穿戴者提供移动辅助，减少掉落伤害至掉落高度减少 4 格的等级，并降低一半的掉落伤害。
 
 //流体
 fluid.hydrochloric_acid=盐酸
@@ -413,7 +413,7 @@ info.qmd.item.amount=含量：%s / %s
 //info.qmd.item.cell_warning=警告：单元中含有相当易反应的物质，不要让这些物质离开单元！
 
 //玩家信息
-message.qmd.atmosphere_collector=正在以%2$s的速率收集%1$s
+message.qmd.atmosphere_collector=正在以 %2$s 的速率收集%1$s
 message.qmd.atmosphere_collector_no_fluid=未在收集气体
 
 //多方块
@@ -421,7 +421,7 @@ qmd.multiblock_validation.need_energy_ports=至少要有一个能量端口。
 qmd.multiblock_validation.no_inlet=至少要有一个模式为输入的冷却液出入口。
 qmd.multiblock_validation.no_outlet=至少要有一个模式为输出的冷却液出入口。
 
-qmd.multiblock_validation.accelerator.wrong_height=加速器必须高5格。
+qmd.multiblock_validation.accelerator.wrong_height=加速器必须高 5 格。
 qmd.multiblock_validation.accelerator.invalid_beam_port=束流端口不能位于此处。
 qmd.multiblock_validation.accelerator.something_is_wrong=你把一个束流端口塞在结构里头了。额，所以，你是怎么打算的？
 qmd.multiblock_validation.accelerator.no_yokes=这种加速器中不能有电磁轭。
@@ -434,32 +434,33 @@ qmd.multiblock_validation.accelerator.linear.must_be_beam=线性加速器的中�
 qmd.multiblock_validation.accelerator.linear.have_source_and_beam_port=束流的一个末端必须有一个离子源，另一端则必须有一个束流端口。
 qmd.multiblock_validation.accelerator.linear.source_must_face_in=离子源必须正对束流。
 qmd.multiblock_validation.accelerator.linear.must_have_io=加速器束流的两端必须各有一个束流端口，一个输入，一个输出。
+qmd.multiblock_validation.accelerator.linear.must_be_5_wide=线性加速器必须宽 5 格。
 
-qmd.multiblock_validation.accelerator.ring.must_be_square=加速器在X轴与Z轴上的长度必须相等。
+qmd.multiblock_validation.accelerator.ring.must_be_square=加速器在 X 轴与 Z 轴上的长度必须相等。
 qmd.multiblock_validation.accelerator.ring.to_short=同步加速器还不够大。
 qmd.multiblock_validation.accelerator.ring.to_long=同步加速器太大了。
 qmd.multiblock_validation.accelerator.ring.must_be_beam=加速器中央的束流方块周围必须有一个环。
-qmd.multiblock_validation.accelerator.ring.must_be_dipole_in_conner=加速器的每个转角处都必须有一个双极磁铁。若想构造有效双极磁铁结构则束流方块的上方与下方都必须有一个电磁铁，周围3x3x3范围内束流方块与电磁铁以外的所有空位都必须以电磁轭填充。
+qmd.multiblock_validation.accelerator.ring.must_be_dipole_in_conner=加速器的每个转角处都必须有一个双极磁铁。若想构造有效双极磁铁结构则束流方块的上方与下方都必须有一个电磁铁，周围 3x3x3 范围内束流方块与电磁铁以外的所有空位都必须以电磁轭填充。
 qmd.multiblock_validation.accelerator.ring.must_be_dipole=束流端口通入处必须有一个双极磁铁。
 qmd.multiblock_validation.accelerator.ring.beam_port_must_connect=必须有一个束流方块与束流端口相连接。
 qmd.multiblock_validation.accelerator.ring.must_have_io=必须只有一个模式为输入的束流端口和一个模式为输出的束流端口。
 qmd.multiblock_validation.accelerator.ring.to_many_synchrotron_ports=只能有一个同步端口。
 
-qmd.multiblock_validation.beam_director.must_be_cube=束流转向器必须是一个5x5x5的，内有一个双极磁铁的正方体。
+qmd.multiblock_validation.beam_director.must_be_cube=束流转向器必须是一个 5x5x5 的，内有一个双极磁铁的正方体。
 qmd.multiblock_validation.beam_director.must_be_beam=中央必须有一个束流方块。
 qmd.multiblock_validation.beam_director.must_be_dipole=中央必须有一个垂直的或对角的双极磁铁。
 
 qmd.multiblock_validation.chamber.must_have_target=靶室中央必须有一个粒子室。
 qmd.multiblock_validation.chamber.must_be_beam=粒子室与每个束流端口之间都必须有成条的粒子室束流方块。
 qmd.multiblock_validation.chamber.beam_port_wrong_spot=束流端口必须位于一个面的中央。
-qmd.multiblock_validation.chamber.must_be_square=所有室X轴与Z轴上的长度都必须相等。
+qmd.multiblock_validation.chamber.must_be_square=所有室 X 轴与 Z 轴上的长度都必须相等。
 qmd.multiblock_validation.chamber.must_be_odd=所有室的宽度都必须是奇数。
 qmd.multiblock_validation.chamber.must_have_input_beam=必须要有一个模式为输入的束流端口。
 
 qmd.multiblock_validation.chamber.beam_dump.only_input_beam=束流收集器只能有一个模式为输入的束流端口。
 qmd.multiblock_validation.chamber.beam_dump.must_have_fluid_output=束流收集器必须有一个模式为输出的束流端口。
 
-qmd.multiblock_validation.containment.must_be_square=遏制器X轴与Z轴上的长度都必须相等。
+qmd.multiblock_validation.containment.must_be_square=遏制器 X 轴与 Z 轴上的长度都必须相等。
 qmd.multiblock_validation.containment.must_be_odd=遏制器的宽度必须是奇数。
 
 qmd.multiblock_validation.containment.neutral.must_be_coil=顶部与底部必须有一个由遏制器线圈构成的环。
@@ -467,7 +468,7 @@ qmd.multiblock_validation.containment.neutral.beam_port_or_laser=这一面的中
 qmd.multiblock_validation.containment.neutral.must_be_laser=这一面的中央必须有一个遏制器激光器。
 qmd.multiblock_validation.containment.neutral.must_be_input_beam=这一面的中央必须有一个模式为输入的束流端口。
 
-qmd.multiblock_validation.collision_chamber.wrong_length=碰撞室必须长17格。
+qmd.multiblock_validation.collision_chamber.wrong_length=碰撞室必须长 17 格。
 qmd.multiblock_validation.collision_chamber.must_be_odd_square=终点处的面必须是边长为奇数格的正方形。
 qmd.multiblock_validation.collision_chamber.must_be_target=碰撞室的中央必须有一根由粒子室方块构成的长条。
 qmd.multiblock_validation.collision_chamber.must_be_beam=这必须是一个粒子室束流方块。
@@ -475,8 +476,8 @@ qmd.multiblock_validation.collision_chamber.must_be_input_beam_port=这必须是
 qmd.multiblock_validation.collision_chamber.must_be_output_beam_port=这必须是一个模式为输出的粒子室束流端口。
 
 //容器与GUI
-gui.qmd.container.heat_stored=热量存储：%s/%s
-gui.qmd.container.energy_stored=能量存储：%s/%s
+gui.qmd.container.heat_stored=热量存储：%s / %s
+gui.qmd.container.energy_stored=能量存储：%s / %s
 gui.qmd.container.required_energy=需要能量：%s
 gui.qmd.container.temperature=温度：%s
 
@@ -496,7 +497,7 @@ gui.qmd.container.accelerator.efficiency=（%s%%）
 gui.qmd.container.accelerator.cooling=冷却：%s
 gui.qmd.container.accelerator.heating=最大加热：%s
 gui.qmd.container.accelerator.external_heating=最大外部加热：%s
-gui.qmd.container.accelerator.coolant_stored=冷却液存储：%s/%s
+gui.qmd.container.accelerator.coolant_stored=冷却液存储：%s / %s
 gui.qmd.container.accelerator.coolant_required=冷却液使用：%s
 gui.qmd.container.accelerator.coolant_out=热冷却液输出：%s
 
@@ -544,19 +545,19 @@ qmd.particle.electron.name=电子
 qmd.particle.positron.name=正电子
 qmd.particle.electron_neutrino.name=电子中微子
 qmd.particle.electron_antineutrino.name=电子反中微子
-qmd.particle.muon.name=μ轻子
-qmd.particle.antimuon.name=反μ轻子
-qmd.particle.muon_neutrino.name=μ中微子
-qmd.particle.muon_antineutrino.name=μ反中微子
-qmd.particle.tau.name=τ轻子
-qmd.particle.antitau.name=反τ轻子
-qmd.particle.tau_neutrino.name=τ中微子
-qmd.particle.tau_antineutrino.name=τ反中微子
+qmd.particle.muon.name=μ 轻子
+qmd.particle.antimuon.name=反 μ 轻子
+qmd.particle.muon_neutrino.name=μ 中微子
+qmd.particle.muon_antineutrino.name=μ 反中微子
+qmd.particle.tau.name=τ 轻子
+qmd.particle.antitau.name=反 τ 轻子
+qmd.particle.tau_neutrino.name=τ 中微子
+qmd.particle.tau_antineutrino.name=τ 反中微子
 qmd.particle.photon.name=光子
 qmd.particle.gluon.name=胶子
-qmd.particle.w_plus_boson.name=W+玻色子
-qmd.particle.w_minus_boson.name=W-玻色子
-qmd.particle.z_boson.name=Z玻色子
+qmd.particle.w_plus_boson.name=W+ 玻色子
+qmd.particle.w_minus_boson.name=W- 玻色子
+qmd.particle.z_boson.name=Z 玻色子
 qmd.particle.higgs_boson.name=希格斯玻色子
 qmd.particle.proton.name=质子
 qmd.particle.antiproton.name=反质子
@@ -566,30 +567,30 @@ qmd.particle.deuteron.name=氘核
 qmd.particle.antideuteron.name=反氘核
 qmd.particle.alpha.name=阿尔法粒子
 qmd.particle.antialpha.name=反阿尔法粒子
-qmd.particle.pion_plus.name=π介子 +
-qmd.particle.pion_naught.name=π介子 0
-qmd.particle.pion_minus.name=π介子 -
+qmd.particle.pion_plus.name=π 介子 +
+qmd.particle.pion_naught.name=π 介子 0
+qmd.particle.pion_minus.name=π 介子 -
 qmd.particle.triton.name=氚核
 qmd.particle.antitriton.name=反氚核
 qmd.particle.helion.name=氦核
 qmd.particle.antihelion.name=反氦核
 qmd.particle.boron_ion.name=硼离子
-qmd.particle.calcium_48_ion.name=钙-48离子
-qmd.particle.kaon_plus.name=k介子 +
-qmd.particle.kaon_naught.name=k介子 0
-qmd.particle.antikaon_naught.name=反k介子 0
-qmd.particle.kaon_minus.name=k介子 -
-qmd.particle.eta.name=η介子
-qmd.particle.eta_prime.name=η素介子
-qmd.particle.charmed_eta.name=η粲介子
-qmd.particle.bottom_eta.name=η底介子
+qmd.particle.calcium_48_ion.name=钙-48 离子
+qmd.particle.kaon_plus.name=k 介子 +
+qmd.particle.kaon_naught.name=k 介子 0
+qmd.particle.antikaon_naught.name=反 k 介子 0
+qmd.particle.kaon_minus.name=k 介子 -
+qmd.particle.eta.name=η 介子
+qmd.particle.eta_prime.name=η 素介子
+qmd.particle.charmed_eta.name=η 粲介子
+qmd.particle.bottom_eta.name=η 底介子
 qmd.particle.glueball.name=胶球
-qmd.particle.sigma_plus.name=Σ重子 +
-qmd.particle.antisigma_plus.name=反Σ重子 +
-qmd.particle.sigma_naught.name=Σ重子 0
-qmd.particle.antisigma_naught.name=反Σ重子 0
-qmd.particle.sigma_minus.name=Σ重子 -
-qmd.particle.antisigma_minus.name=反Σ重子 -
+qmd.particle.sigma_plus.name=Σ 重子 +
+qmd.particle.antisigma_plus.name=反 Σ 重子 +
+qmd.particle.sigma_naught.name=Σ 重子 0
+qmd.particle.antisigma_naught.name=反 Σ 重子 0
+qmd.particle.sigma_minus.name=Σ 重子 -
+qmd.particle.antisigma_minus.name=反 Σ 重子 -
 
 //粒子描述
 qmd.particle.up_quark.desc=上夸克是次轻的夸克。上下夸克结合在一起以构成质子和中子。
@@ -608,19 +609,19 @@ qmd.particle.electron.desc=电子是最轻的荷电粒子。它们一般位于�
 qmd.particle.positron.desc=正电子是电子对应的反物质。当电子与正电子相遇时，湮灭将会导致所有的质量被转化为形式为两束伽马射线的能量。
 qmd.particle.electron_neutrino.desc=电子中微子是常与电子相伴的中微子。
 qmd.particle.electron_antineutrino.desc=反电子中微子是电子中微子对应的反物质。
-qmd.particle.muon.desc=μ轻子基本是一个重的电子。
-qmd.particle.antimuon.desc=反μ轻子是μ轻子对应的反物质。
-qmd.particle.muon_neutrino.desc=μ中微子是常与μ轻子相伴的中微子。
-qmd.particle.muon_antineutrino.desc=反μ中微子是μ中微子对应的反物质。
-qmd.particle.tau.desc=τ轻子基本是一个非常重的电子。
-qmd.particle.antitau.desc=反τ轻子是τ轻子对应的反物质。
-qmd.particle.tau_neutrino.desc=τ中微子是常与τ轻子相伴的中微子。
-qmd.particle.tau_antineutrino.desc=反τ中微子是τ中微子对应的反物质。
+qmd.particle.muon.desc=μ 轻子基本是一个重的电子。
+qmd.particle.antimuon.desc=反 μ 轻子是 μ 轻子对应的反物质。
+qmd.particle.muon_neutrino.desc=μ 中微子是常与 μ 轻子相伴的中微子。
+qmd.particle.muon_antineutrino.desc=反 μ 中微子是 μ 中微子对应的反物质。
+qmd.particle.tau.desc=τ 轻子基本是一个非常重的电子。
+qmd.particle.antitau.desc=反 τ 轻子是 τ 轻子对应的反物质。
+qmd.particle.tau_neutrino.desc=τ 中微子是常与 τ 轻子相伴的中微子。
+qmd.particle.tau_antineutrino.desc=反 τ 中微子是 τ 中微子对应的反物质。
 qmd.particle.photon.desc=光子是构成光的粒子。光子是电磁力的载体。高能光子被称为伽马射线。
 qmd.particle.gluon.desc=胶子是强力的载体。强力是令夸克结合在一起构成包括光子等的复合粒子的力。
-qmd.particle.w_plus_boson.desc=Z和W玻色子是弱力的载体。弱力制约放射性衰变，并是β衰变的原因。
-qmd.particle.w_minus_boson.desc=Z和W玻色子是弱力的载体。弱力制约放射性衰变，并是β衰变的原因。
-qmd.particle.z_boson.desc=Z和W玻色子是弱力的载体。弱力制约放射性衰变，并是β衰变的原因。
+qmd.particle.w_plus_boson.desc=Z 和 W 玻色子是弱力的载体。弱力制约放射性衰变，也是 β 衰变的原因。
+qmd.particle.w_minus_boson.desc=Z 和 W 玻色子是弱力的载体。弱力制约放射性衰变，也是 β 衰变的原因。
+qmd.particle.z_boson.desc=Z和W玻色子是弱力的载体。弱力制约放射性衰变，也是β衰变的原因。
 qmd.particle.higgs_boson.desc=希格斯玻色子是给予粒子质量的希格斯场中的玻色子。
 qmd.particle.proton.desc=质子是核子之一，与中子一同构成原子核。
 qmd.particle.antiproton.desc=反质子是质子对应的反物质。
@@ -628,36 +629,36 @@ qmd.particle.neutron.desc=中子是核子之一，与质子一同构成原子核
 qmd.particle.antineutron.desc=反中子是中子对应的反物质。
 qmd.particle.deuteron.desc=氘核是氘原子的原子核。
 qmd.particle.antideuteron.desc=反氘核是氘核对应的反物质。
-qmd.particle.alpha.desc=阿尔法粒子是氦-4原子的原子核的别称。铀、钚一类重元素衰变时会出现。
+qmd.particle.alpha.desc=阿尔法粒子是氦-4 原子的原子核的别称。铀、钚一类重元素衰变时会出现。
 qmd.particle.antialpha.desc=反阿尔法粒子是阿尔法粒子对应的反物质。
-qmd.particle.pion_plus.desc=π介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
-qmd.particle.pion_naught.desc=π介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
-qmd.particle.pion_minus.desc=π介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
+qmd.particle.pion_plus.desc=π 介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
+qmd.particle.pion_naught.desc=π 介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
+qmd.particle.pion_minus.desc=π 介子是让核子组在一起的粒子。尽管它们本身并未着色，它们之间仍然分布着“残余的”强力以组合核子。
 qmd.particle.triton.desc=氚核是氚原子的原子核。
 qmd.particle.antitriton.desc=反氚核是氚核对应的反物质。
-qmd.particle.helion.desc=氦核是氦-3原子的原子核。
+qmd.particle.helion.desc=氦核是氦-3 原子的原子核。
 qmd.particle.antihelion.desc=反氦核是氦核对应的反物质。
 
 qmd.particle.boron_ion.desc=失去了一个电子的硼原子。
-qmd.particle.calcium_48_ion.desc=失去了一个电子的钙-48原子。富含大量中子，可用于合成超重元素。
+qmd.particle.calcium_48_ion.desc=失去了一个电子的钙-48 原子。富含大量中子，可用于合成超重元素。
 
-qmd.particle.kaon_plus.desc=k介子 +是奇异性为1的介子。
-qmd.particle.kaon_naught.desc=k介子 0是奇异性为1的介子。
-qmd.particle.antikaon_naught.desc=反k介子 0是奇异性为-1的介子。
-qmd.particle.kaon_minus.desc=k介子 -是奇异性为1的介子。
+qmd.particle.kaon_plus.desc=k 介子 + 是奇异性为 1 的介子。
+qmd.particle.kaon_naught.desc=k 介子 0 是奇异性为 1 的介子。
+qmd.particle.antikaon_naught.desc=反 k 介子 0 是奇异性为 -1 的介子。
+qmd.particle.kaon_minus.desc=k 介子 - 是奇异性为 1 的介子。
 
-qmd.particle.eta.desc=η介子是无味介子，也即奇异性与同位旋皆为0的介子。
-qmd.particle.eta_prime.desc=η介子是无味介子，也即奇异性与同位旋皆为0的介子。
-qmd.particle.charmed_eta.desc=η介子是无味介子，也即奇异性与同位旋皆为0的介子。
-qmd.particle.bottom_eta.desc=η介子是无味介子，也即奇异性与同位旋皆为0的介子。
+qmd.particle.eta.desc=η 介子是无味介子，也即奇异性与同位旋皆为 0 的介子。
+qmd.particle.eta_prime.desc=η 介子是无味介子，也即奇异性与同位旋皆为 0 的介子。
+qmd.particle.charmed_eta.desc=η 介子是无味介子，也即奇异性与同位旋皆为 0 的介子。
+qmd.particle.bottom_eta.desc=η 介子是无味介子，也即奇异性与同位旋皆为 0 的介子。
 qmd.particle.glueball.desc=胶球是完全由胶子构成的粒子。
 
-qmd.particle.sigma_plus.desc=Σ重子含有一个奇夸克。它们比质子和中子重。
-qmd.particle.antisigma_plus.desc=反Σ重子含有一个反奇夸克。它们比反质子和反中子重。
-qmd.particle.sigma_naught.desc=Σ重子含有一个奇夸克。它们比质子和中子重。
-qmd.particle.antisigma_naught.desc=反Σ重子含有一个反奇夸克。它们比反质子和反中子重。
-qmd.particle.sigma_minus.desc=Σ重子含有一个奇夸克。它们比质子和中子重。
-qmd.particle.antisigma_minus.desc=反Σ重子含有一个反奇夸克。它们比反质子和反中子重。
+qmd.particle.sigma_plus.desc=Σ 重子含有一个奇夸克。它们比质子和中子重。
+qmd.particle.antisigma_plus.desc=反 Σ 重子含有一个反奇夸克。它们比反质子和反中子重。
+qmd.particle.sigma_naught.desc=Σ 重子含有一个奇夸克。它们比质子和中子重。
+qmd.particle.antisigma_naught.desc=反 Σ 重子含有一个反奇夸克。它们比反质子和反中子重。
+qmd.particle.sigma_minus.desc=Σ 重子含有一个奇夸克。它们比质子和中子重。
+qmd.particle.antisigma_minus.desc=反 Σ 重子含有一个反奇夸克。它们比反质子和反中子重。
 
 //粒子信息
 gui.qmd.particlestack.amount=数量：%s
@@ -764,7 +765,7 @@ gui.qmd.config.processors.time.comment=每个机器的基础处理时间（单�
 // 默认：[400,200]。
 
 gui.qmd.config.processors.atmosphere_collector_recipes=大气收集器配方
-gui.qmd.config.processors.atmosphere_collector_recipes.comment=定义不同维度中大气收集器收集的资源。格式：'维度ID:流体名称:收集速率（单位：mB/t）'。
+gui.qmd.config.processors.atmosphere_collector_recipes.comment=定义不同维度中大气收集器收集的资源。格式：'维度 ID:流体名称:收集速率（单位：mB/t）'。
 
 //gui.qmd.config.processors.irradiator_fuel_life_time=基础辐照器燃料时间
 //gui.qmd.config.processors.irradiator_fuel_life_time.comment=辐照器燃料的基础燃烧时间（单位：秒）。
@@ -941,8 +942,8 @@ gui.qmd.config.tools.armor_toughness.comment=盔甲的韧性。顺序：HEV。
 gui.qmd.config.tools.armor_hev=HEV盔甲护甲值
 gui.qmd.config.tools.armor_hev.comment=不同部位盔甲的有效护甲值。顺序：靴子，护腿，胸甲，头盔。
 
-gui.qmd.config.tools.rad_res_hev=HEV盔甲辐射抗性
-gui.qmd.config.tools.rad_res_hev.comment=HEV盔甲不同部位的辐射抗性。顺序：靴子，护腿，胸甲，头盔。
+gui.qmd.config.tools.rad_res_hev=HEV 盔甲辐射抗性
+gui.qmd.config.tools.rad_res_hev.comment=HEV 盔甲不同部位的辐射抗性。顺序：靴子，护腿，胸甲，头盔。
 
 gui.qmd.config.containment.max_temp.comment=遏制器结构的最大操作温度（单位：K）。
 // 默认：[104。
@@ -953,27 +954,30 @@ gui.qmd.config.containment.part_heat=遏制器各部热量
 gui.qmd.config.containment.part_power.comment=遏制器基础的能量消耗（单位：RF/t）。顺序：遏制器线圈，遏制器激光器].
 // 默认：[8000,10000。
 gui.qmd.config.containment.part_power=遏制器各部功率
-gui.qmd.config.copernicium_criticality.comment=燃料的临界系数。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_criticality.comment=燃料的临界系数。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[20,25,35,20。
 gui.qmd.config.copernicium_criticality=鎶燃料临界系数
-gui.qmd.config.copernicium_efficiency.comment=燃料的基础效能。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_efficiency.comment=燃料的基础效能。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[5.0,5.0,5.0,5.0。
 gui.qmd.config.copernicium_efficiency=鎶燃料基础效能
-gui.qmd.config.copernicium_fuel_time.comment=燃料衰竭所需的时间。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_fuel_time.comment=燃料衰竭所需的时间。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[10000,10000,12004,9001。
 gui.qmd.config.copernicium_fuel_time=鎶燃料衰竭时间
-gui.qmd.config.copernicium_heat_generation.comment=燃料基础的热量产出。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_heat_generation.comment=燃料基础的热量产出。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[2000,2000,1666,2222。
 gui.qmd.config.copernicium_heat_generation=鎶燃料产热
-gui.qmd.config.copernicium_radiation.comment=燃料在处理时会产生的辐射。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_radiation.comment=燃料在处理时会产生的辐射。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[8.33E-4,8.33E-4,8.33E-4,8.33E-4。
 gui.qmd.config.copernicium_radiation=鎶燃料辐射
-gui.qmd.config.copernicium_self_priming.comment=鎶燃料是否为强中子射源。顺序：混合TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+gui.qmd.config.copernicium_self_priming.comment=鎶燃料是否为强中子射源。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
 // 默认：[true,true,true,true。
+gui.qmd.config.copernicium_decay_factor=鎶燃料衰变系数
+gui.qmd.config.copernicium_decay_factor.comment=鎶燃料的衰变系数。顺序：混合 TRISO-291，混合氧化物-291，混合氮化物-291，混合锆合金-291。
+
 gui.qmd.config.copernicium_self_priming=鎶燃料强中子射源设定
 gui.qmd.config.other.item_ticker_chunks_per_tick.comment=本模组在包含的方块实体中检查物品的区块数（单位：区块/t）。这被用于自存于方块实体中的反物质单元中排出能量。设定值过高会导致卡顿，设定为0以禁用。
 // 默认：[5。
-gui.qmd.config.other.item_ticker_chunks_per_tick=每t区块检查数
+gui.qmd.config.other.item_ticker_chunks_per_tick=每 t 区块检查数
 gui.qmd.config.other.override_nc_recipes.comment=允许本模组覆盖核电工艺的配方以带来更好的游戏体验。
 // 默认：[true。
 gui.qmd.config.other.override_nc_recipes=覆盖核电工艺配方
@@ -1033,3 +1037,9 @@ gui.qmd.config.other.turbine_blade_efficiency.comment=涡轮机转子叶片的�
 
 gui.qmd.config.other.turbine_blade_expansion=转子叶片膨胀系数
 gui.qmd.config.other.turbine_blade_expansion.comment=涡轮机转子叶片的膨胀。顺序：超级合金。
+
+# 如有不符合《中文文案排版指北》的内容和未正常转义的 % 请务必告知，万分感谢
+# 以下三行亟需协助
+# gui.qmd.container.accelerator.cavities
+# gui.qmd.container.accelerator.quadrupoles
+# gui.qmd.container.accelerator.dipoles


### PR DESCRIPTION
This is the last time I submit CHS translation to this repository, later translations will all go to the [CFPA repository](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.16/README-en.md).

> I have decided against sending translations to official repositories, and instead of that I will send translations to the CFPA repository, which is a commonized CHS translation integration of over 1000 mods. It was just a little bit troublesome for me to synchronise the translations of both sides (official and CFPA), and there are benefits to do translating for CFPA, because it has a better reviewing-feedback translation processing system, and it provides better CHS character rendering for its translations. I will still update NuclearCraft for its official repository, because there is a ModID conflict between NC and NCO in CFPA repository, but other mods I am working on will only be updated in CFPA repository.

The main reason is that some Chinese characters can not be shown correctly only with the translation in the QMD mod, it requires the fix from CFPA, so submitting translations to CFPA can encourage players to get better gameplay.