### PR TITLE
Fixed bug where fluids will disappear from multiblocks on world restart.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,6 @@ repositories {
 		url = "http://maven.blamejared.com/"
 	}
 	maven {
-		name = "ic2"
-		url = "http://maven.ic2.player.to/"
-	}
-	maven {
 		name = "cil"
 		url = "http://maven.cil.li/"
 	}

--- a/src/main/java/lach_01298/qmd/accelerator/LinearAcceleratorLogic.java
+++ b/src/main/java/lach_01298/qmd/accelerator/LinearAcceleratorLogic.java
@@ -63,10 +63,12 @@ public class LinearAcceleratorLogic extends AcceleratorLogic
 		
 		
 		//on the rare occasion of changing the multiblock to a different type with the tank full
+		/*
 		if(!(oldLogic instanceof LinearAcceleratorLogic))
 		{
 			getMultiblock().tanks.get(2).setFluidStored(null);
 		}
+		*/
 	}
 
 	@Override

--- a/src/main/java/lach_01298/qmd/accelerator/MassSpectrometerLogic.java
+++ b/src/main/java/lach_01298/qmd/accelerator/MassSpectrometerLogic.java
@@ -72,6 +72,7 @@ public class MassSpectrometerLogic extends AcceleratorLogic
 		*/
 		
 		//on the rare occasion of changing the multiblock to a different type with the tank full
+		/*
 		if(!(oldLogic instanceof MassSpectrometerLogic))
 		{
 			getMultiblock().tanks.get(2).setFluidStored(null);
@@ -81,6 +82,7 @@ public class MassSpectrometerLogic extends AcceleratorLogic
 			getMultiblock().tanks.get(6).setFluidStored(null);
 			
 		}
+		*/
 	}
 
 	

--- a/src/main/java/lach_01298/qmd/vacuumChamber/ExoticContainmentLogic.java
+++ b/src/main/java/lach_01298/qmd/vacuumChamber/ExoticContainmentLogic.java
@@ -80,11 +80,12 @@ public class ExoticContainmentLogic extends VacuumChamberLogic
 		*/
 		
 		//on the rare occasion of changing the multiblock to a different type with the tank full
+		/*
 		if(!(oldLogic instanceof ExoticContainmentLogic))
 		{
 			getMultiblock().tanks.get(2).setFluidStored(null);
 		}
-		
+		*/
 	}
 
 	@Override

--- a/src/main/java/lach_01298/qmd/vacuumChamber/NucleosynthesisChamberLogic.java
+++ b/src/main/java/lach_01298/qmd/vacuumChamber/NucleosynthesisChamberLogic.java
@@ -101,6 +101,7 @@ public class NucleosynthesisChamberLogic extends VacuumChamberLogic
 		*/
 		
 		//on the rare occasion of changing the multiblock to a different type with the tank full
+		/*
 		if(!(oldLogic instanceof NucleosynthesisChamberLogic))
 		{
 			getMultiblock().tanks.get(2).setFluidStored(null);
@@ -111,6 +112,7 @@ public class NucleosynthesisChamberLogic extends VacuumChamberLogic
 			getMultiblock().tanks.get(7).setFluidStored(null);
 			
 		}
+		*/
 	}
 
 	@Override


### PR DESCRIPTION
As I said [here](https://discord.com/channels/425461908712325130/687368090484605031/1236157784337420369), "when a multiblock object is first initialized, the logic is set to the parent logic (e.g., a linear accelerator's logic is set to `AcceleratorLogic` rather than `LinearAcceleratorLogic`)", so "checking if the logic is the correct subtype (such as with `oldLogic instanceof NucleosynthesisChamberLogic`) in the constructor will always return false, as then the logic is still the parent logic", causing fluids to disappear from multiblocks on world restart because the code clears the fluid tanks if the `oldLogic` does not match the correct subtype during initialization, which always happens due to the above. To fix the issue, I simply commented out those pieces of code.

Multiblocks fixed: linear accelerator, mass spectrometer, exotic containment chamber, and nucleosynthesis chamber.

I also removed the `http://maven.ic2.player.to/` maven repository from `build.gradle` as that link appears to be dead.